### PR TITLE
메인화면 - 캘린더뷰 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
+    implementation 'com.prolificinteractive:material-calendarview:1.4.3'
 
     implementation("androidx.compose.ui:ui:$compose_version")
     // Tooling support (Previews, etc.)

--- a/app/src/main/java/com/wap/storemanagement/ui/home/composeview/OffMemberView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/composeview/OffMemberView.kt
@@ -35,7 +35,7 @@ fun OffMemberLazyList() {
 
 @Preview
 @Composable
-fun Ad() {
+private fun OffMemberPreview() {
     Column() {
         OffMemberTitle()
         OffMemberLazyList()

--- a/app/src/main/res/color/custom_date_color.xml
+++ b/app/src/main/res/color/custom_date_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/white" />
+    <item android:color="@color/black" />
+</selector>

--- a/app/src/main/res/layout/calendar_view.xml
+++ b/app/src/main/res/layout/calendar_view.xml
@@ -5,13 +5,15 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        >
+        android:layout_height="match_parent">
 
         <com.prolificinteractive.materialcalendarview.MaterialCalendarView
-            android:id="@+id/calendar"
+            android:id="@+id/calendar_home"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:mcv_headerTextAppearance="@style/CalendarWidgetHeader"
+            app:mcv_weekDayTextAppearance="@style/CalendarWidgetDay"
+            app:mcv_dateTextAppearance="@style/CalendarWidgetDate"
             app:mcv_selectionColor="@color/dark_blue"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/calendar_view.xml
+++ b/app/src/main/res/layout/calendar_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+
+        <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+            android:id="@+id/calendar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:mcv_selectionColor="@color/dark_blue"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,9 +10,13 @@
     <color name="white">#FFFFFFFF</color>
     <color name="sky_blue">#87CEFA</color>
     <color name="gray">#939393</color>
+    <color name="dark_blue">#2F84B9</color>
 
     <color name="profile_border">@color/sky_blue</color>
     <color name="profile_background">@color/white</color>
+
+    <color name="calendar_today">@color/sky_blue</color>
+    <color name="calendar_select">@color/dark_blue</color>
 
     <color name="gray_text">@color/gray</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,4 +13,20 @@
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="CalendarWidgetHeader">
+        <item name="android:textSize">20sp</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="CalendarWidgetDay">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+
+    <style name="CalendarWidgetDate">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/custom_date_color</item>
+    </style>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.4"


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #15 

## Changes
<!-- 변경사항 -->

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
문제 : 캘린더 뷰 dateTextAppearance의 text_color를 설정해주니 날짜 선택시 색상이 변경되지 않음
해결 : xml selector로 check됐을 때, 안됐을 때 색을 따로 지정해줌

라이브러리 출처
https://github.com/prolificinteractive/material-calendarview