### PR TITLE
SchedulDao startTime 자료형 변경

### DIFF
--- a/data/src/main/java/com/wap/data/db/dao/ScheduleDao.kt
+++ b/data/src/main/java/com/wap/data/db/dao/ScheduleDao.kt
@@ -2,6 +2,7 @@ package com.wap.data.db.dao
 
 import androidx.room.*
 import com.wap.data.entity.ScheduleEntity
+import java.time.LocalDateTime
 
 @Dao
 interface ScheduleDao {
@@ -16,7 +17,7 @@ interface ScheduleDao {
     fun findSchedulesByUserId(userId: Long): List<ScheduleEntity>?
 
     @Query("SELECT * FROM SCHEDULE WHERE startTime = :startTime")
-    fun findSchedulesByStartDate(startTime: Long): List<ScheduleEntity>?
+    fun findSchedulesByStartDate(startTime: LocalDateTime): List<ScheduleEntity>?
 
 
     // Update
@@ -29,6 +30,6 @@ interface ScheduleDao {
     fun deleteSchedulesByUserId(userId: Long)
 
     @Query("DELETE FROM SCHEDULE WHERE startTime =:startTime")
-    fun deleteScheduleByStartTime(startTime: Long)
+    fun deleteScheduleByStartTime(startTime: LocalDateTime)
 
 }


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #41 

## Changes
- `SchedulDao` `startTime` 자료형 `Long` -> `LocalDateTime`

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
- `Database`에서 `@TypeConvertersConverters`를 달아 자료형을 변환하기 때문에 `Dao`에서는 `startTime`의 자료형을 `LocalDateTime`으로 하는 것이 맞는것 같아 수정했습니다.