### PR TITLE
ScheduleEntity, UserDao 문제로 인한 build문제 해결

### DIFF
--- a/data/src/main/java/com/wap/data/db/dao/UserDao.kt
+++ b/data/src/main/java/com/wap/data/db/dao/UserDao.kt
@@ -10,7 +10,7 @@ interface UserDao {
     fun insertUser(user: UserEntity)
 
     @Query("SELECT * FROM user WHERE user_id = :userId")
-    fun getUserByUserId(userId: Long)
+    fun getUserByUserId(userId: Long): UserEntity
 
     @Update
     fun updateUser(user: UserEntity)

--- a/data/src/main/java/com/wap/data/entity/ScheduleEntity.kt
+++ b/data/src/main/java/com/wap/data/entity/ScheduleEntity.kt
@@ -1,10 +1,7 @@
 package com.wap.data.entity
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.PrimaryKey
+import androidx.room.*
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Entity(
@@ -16,7 +13,8 @@ import androidx.room.PrimaryKey
             childColumns = ["user_id"],
             onDelete = ForeignKey.CASCADE
         )
-    ]
+    ],
+    indices = [Index(value = ["user_id"])]
 )
 data class ScheduleEntity(
     @PrimaryKey(autoGenerate = true) val scheduleId: Long = 0,


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #44 

## Changes
- `ScheduleEntity`  `indices` 추가
- `UserDao`에 `getUserByUserId` 반환값 추가 

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
- `ScheduleEntity`의 `PrimaryKey`가 아닌 값을 관계에 사용할 경우
- `parentColumns`의 값이 변경될 때마다 전체 테이블을 검색하게 되는 문제가 발생한다.
- `ScheduleEntity`의 `userId` `Colum` 을 인덱싱할 `column`으로 추가해 쿼리속도를 높일 수 있다.