### PR TITLE
TimePicker Toggle - Composable 추가

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -9,6 +9,7 @@ import com.wap.storemanagement.R
 import com.wap.storemanagement.databinding.ActivityScheduleBinding
 import com.wap.storemanagement.ui.home.ScheduleViewModel
 import com.wap.storemanagement.ui.schedule.composeview.*
+import com.wap.storemanagement.ui.schedule.composeview.timepicker.TimePickerView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/TimePicker.kt
@@ -1,11 +1,20 @@
 package com.wap.storemanagement.ui.schedule.composeview
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 
@@ -15,6 +24,7 @@ fun TimePickerView(
     onDismiss: () -> Unit
 ) {
     if (showDialog) {
+
         Dialog(
             onDismissRequest = { onDismiss() }
         ) {
@@ -31,12 +41,78 @@ fun TimePickerView(
                     Text(text = "시작 시간")
                     Text(text = "종료 시간")
                 }
-                Text(text = "Time Picker")
+                 TimePickerToggle("StartTime") {
+                 }
                 Row() {
                     Text(text = "취소")
                     Text(text = "확인")
                 }
             }
         }
+    }
+}
+
+
+// 출처: https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
+@Composable
+fun TimePickerToggle(
+    selectedOption: String,
+    onOptionSelect: (String) -> Unit
+) {
+    val options: List<String> = listOf("StartTime", "EndTime")
+    require(options.contains(selectedOption)) { "Invalid selected option [$selectedOption]" }
+
+    Layout(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(50))
+            .background(color = Color.White),
+        content = {
+            options.forEach { option ->
+                Box(
+                    modifier = Modifier
+                        .clickable { onOptionSelect(option) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = option,
+                        style = MaterialTheme.typography.body1,
+                        color = Color.Black,
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    ) { measurables, constraints ->
+
+        val optionWidth = constraints.maxWidth / options.size
+
+        val optionConstraints = Constraints.fixed(
+            width = optionWidth,
+            height = constraints.maxHeight,
+        )
+
+        val optionPlaceables = measurables
+            .map { measurable -> measurable.measure(optionConstraints) }
+
+        layout(
+            width = constraints.maxWidth,
+            height = constraints.maxHeight,
+        ) {
+            optionPlaceables.forEachIndexed { index, placeable ->
+                placeable.placeRelative(
+                    x = optionWidth * index,
+                    y = 0
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 300, heightDp = 60)
+@Composable
+private fun PreviewTimePicker() {
+    TimePickerToggle("StartTime") {
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -1,21 +1,15 @@
-package com.wap.storemanagement.ui.schedule.composeview
+package com.wap.storemanagement.ui.schedule.composeview.timepicker
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 
@@ -25,6 +19,9 @@ fun TimePickerView(
     onDismiss: () -> Unit
 ) {
     if (showDialog) {
+        val options: List<String> = listOf("StartTime", "EndTime")
+        val selectedOption = remember { mutableStateOf(options.first()) }
+        val roundedCornerPercent = 50
 
         Dialog(
             onDismissRequest = { onDismiss() }
@@ -32,113 +29,22 @@ fun TimePickerView(
             Column(
                 Modifier
                     .size(280.dp, 260.dp)
+                    .clip(shape = RoundedCornerShape(roundedCornerPercent/4))
                     .background(Color.White),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceAround
-                ) {
-                    Text(text = "시작 시간")
-                    Text(text = "종료 시간")
+                TimePickerToggle(
+                    roundedCornerPercent = roundedCornerPercent,
+                    options = options,
+                    selectedOption = selectedOption.value,
+                ) { option ->
+                    selectedOption.value = option
                 }
-                 TimePickerToggle(TimePickerState.StartTime) {
-                 }
                 Row() {
                     Text(text = "취소")
                     Text(text = "확인")
                 }
             }
         }
-    }
-}
-
-private enum class TimePickerOption {
-    Option,
-    Background
-}
-
-enum class TimePickerState {
-    StartTime,
-    EndTime
-}
-
-// 출처: https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
-@Composable
-fun TimePickerToggle(
-    selectedOption: TimePickerState,
-    onOptionSelect: (TimePickerState) -> Unit
-) {
-    val options = TimePickerState.values()
-    require(options.contains(selectedOption)) { "Invalid selected option [$selectedOption]" }
-
-    Layout(
-        modifier = Modifier
-            .clip(shape = RoundedCornerShape(50))
-            .background(color = Color.White),
-        content = {
-            options.forEach { option ->
-                Box(
-                    modifier = Modifier
-                        .layoutId(TimePickerOption.Option)
-                        .clickable { onOptionSelect(option) },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = option.name,
-                        style = MaterialTheme.typography.body1,
-                        color = Color.Black,
-                        modifier = Modifier.padding(horizontal = 4.dp),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-                Box(
-                    modifier = Modifier
-                        .layoutId(TimePickerOption.Background)
-                        .background(Color.Gray)
-                )
-            }
-        }
-    ) { measurables, constraints ->
-
-        val optionWidth = constraints.maxWidth / options.size
-
-        val optionConstraints = Constraints.fixed(
-            width = optionWidth,
-            height = constraints.maxHeight,
-        )
-
-        val optionPlaceables = measurables
-            .filter { measurable -> measurable.layoutId == TimePickerOption.Option }
-            .map { measurable -> measurable.measure(optionConstraints) }
-
-        val backgroundPlaceable = measurables
-            .first { measurable -> measurable.layoutId == TimePickerOption.Background }
-            .measure(optionConstraints)
-
-        layout(
-            width = constraints.maxWidth,
-            height = constraints.maxHeight,
-        ) {
-            backgroundPlaceable.placeRelative(
-                x = 0,
-                y = 0
-            )
-
-            optionPlaceables.forEachIndexed { index, placeable ->
-                placeable.placeRelative(
-                    x = optionWidth * index,
-                    y = 0
-                )
-            }
-        }
-    }
-}
-
-@Preview(widthDp = 250, heightDp = 60)
-@Composable
-private fun PreviewTimePicker() {
-    TimePickerToggle(TimePickerState.StartTime) {
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
@@ -41,7 +42,7 @@ fun TimePickerView(
                     Text(text = "시작 시간")
                     Text(text = "종료 시간")
                 }
-                 TimePickerToggle("StartTime") {
+                 TimePickerToggle(TimePickerState.StartTime) {
                  }
                 Row() {
                     Text(text = "취소")
@@ -52,14 +53,23 @@ fun TimePickerView(
     }
 }
 
+private enum class TimePickerOption {
+    Option,
+    Background
+}
+
+enum class TimePickerState {
+    StartTime,
+    EndTime
+}
 
 // 출처: https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
 @Composable
 fun TimePickerToggle(
-    selectedOption: String,
-    onOptionSelect: (String) -> Unit
+    selectedOption: TimePickerState,
+    onOptionSelect: (TimePickerState) -> Unit
 ) {
-    val options: List<String> = listOf("StartTime", "EndTime")
+    val options = TimePickerState.values()
     require(options.contains(selectedOption)) { "Invalid selected option [$selectedOption]" }
 
     Layout(
@@ -70,11 +80,12 @@ fun TimePickerToggle(
             options.forEach { option ->
                 Box(
                     modifier = Modifier
+                        .layoutId(TimePickerOption.Option)
                         .clickable { onOptionSelect(option) },
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = option,
+                        text = option.name,
                         style = MaterialTheme.typography.body1,
                         color = Color.Black,
                         modifier = Modifier.padding(horizontal = 4.dp),
@@ -82,6 +93,11 @@ fun TimePickerToggle(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
+                Box(
+                    modifier = Modifier
+                        .layoutId(TimePickerOption.Background)
+                        .background(Color.Gray)
+                )
             }
         }
     ) { measurables, constraints ->
@@ -94,12 +110,22 @@ fun TimePickerToggle(
         )
 
         val optionPlaceables = measurables
+            .filter { measurable -> measurable.layoutId == TimePickerOption.Option }
             .map { measurable -> measurable.measure(optionConstraints) }
+
+        val backgroundPlaceable = measurables
+            .first { measurable -> measurable.layoutId == TimePickerOption.Background }
+            .measure(optionConstraints)
 
         layout(
             width = constraints.maxWidth,
             height = constraints.maxHeight,
         ) {
+            backgroundPlaceable.placeRelative(
+                x = 0,
+                y = 0
+            )
+
             optionPlaceables.forEachIndexed { index, placeable ->
                 placeable.placeRelative(
                     x = optionWidth * index,
@@ -110,9 +136,9 @@ fun TimePickerToggle(
     }
 }
 
-@Preview(widthDp = 300, heightDp = 60)
+@Preview(widthDp = 250, heightDp = 60)
 @Composable
 private fun PreviewTimePicker() {
-    TimePickerToggle("StartTime") {
+    TimePickerToggle(TimePickerState.StartTime) {
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -29,7 +29,7 @@ fun TimePickerView(
             Column(
                 Modifier
                     .size(280.dp, 260.dp)
-                    .clip(shape = RoundedCornerShape(roundedCornerPercent/4))
+                    .clip(shape = RoundedCornerShape(roundedCornerPercent / 4))
                     .background(Color.White),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
@@ -123,7 +123,7 @@ fun TimePickerToggle(
 @Composable
 private fun PreviewTimePicker() {
     val options: List<String> = listOf("StartTime", "EndTime")
-    val selectedOption = remember { mutableStateOf(options.first())}
+    val selectedOption = remember { mutableStateOf(options.first()) }
 
     TimePickerToggle(
         options = options,

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
@@ -1,0 +1,135 @@
+package com.wap.storemanagement.ui.schedule.composeview.timepicker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import com.wap.storemanagement.R
+
+private enum class TimePickerToggleOption {
+    Option,
+    Background
+}
+
+// 출처: https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
+@Composable
+fun TimePickerToggle(
+    options: List<String>,
+    roundedCornerPercent: Int,
+    selectedOption: String,
+    selectedColor: Color = Color.White,
+    unselectedColor: Color = colorResource(id = R.color.gray_text),
+    state: TimePickerToggleState = rememberTimePickerToggleState(
+        options = options,
+        selectedOption = selectedOption,
+        selectedColor = selectedColor,
+        unselectedColor = unselectedColor
+    ),
+    onOptionSelect: (String) -> Unit,
+) {
+    val backgroundColor = colorResource(id = R.color.focused_indicator_color)
+
+    require(options.contains(selectedOption)) { "Invalid selected option [$selectedOption]" }
+
+    LaunchedEffect(key1 = options, key2 = selectedOption) {
+        state.selectOption(this, options.indexOf(selectedOption))
+    }
+
+    Layout(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(roundedCornerPercent))
+            .background(color = Color.White),
+        content = {
+            val colors = state.textColors
+            options.forEachIndexed { index, option ->
+                Box(
+                    modifier = Modifier
+                        .layoutId(TimePickerToggleOption.Option)
+                        .clickable { onOptionSelect(option) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = option,
+                        style = MaterialTheme.typography.body1,
+                        color = colors[index],
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .layoutId(TimePickerToggleOption.Background)
+                        .clip(shape = RoundedCornerShape(roundedCornerPercent))
+                        .background(backgroundColor)
+                )
+            }
+        }
+    ) { measurables, constraints ->
+
+        val optionWidth = constraints.maxWidth / options.size
+
+        val optionConstraints = Constraints.fixed(
+            width = optionWidth,
+            height = constraints.maxWidth / 5,
+        )
+
+        val optionPlaceables = measurables
+            .filter { measurable -> measurable.layoutId == TimePickerToggleOption.Option }
+            .map { measurable -> measurable.measure(optionConstraints) }
+
+        val backgroundPlaceable = measurables
+            .first { measurable -> measurable.layoutId == TimePickerToggleOption.Background }
+            .measure(optionConstraints)
+
+        layout(
+            width = constraints.maxWidth,
+            height = constraints.maxWidth / 5,
+        ) {
+            backgroundPlaceable.placeRelative(
+                x = (state.selectedIndex * optionWidth).toInt(),
+                y = 0
+            )
+
+            optionPlaceables.forEachIndexed { index, placeable ->
+                placeable.placeRelative(
+                    x = optionWidth * index,
+                    y = 0
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 190, heightDp = 300)
+@Composable
+private fun PreviewTimePicker() {
+    val options: List<String> = listOf("StartTime", "EndTime")
+    val selectedOption = remember { mutableStateOf(options.first())}
+
+    TimePickerToggle(
+        options = options,
+        roundedCornerPercent = 50,
+        selectedOption = selectedOption.value
+    ) { option ->
+        selectedOption.value = option
+    }
+}

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggleState.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggleState.kt
@@ -1,0 +1,77 @@
+package com.wap.storemanagement.ui.schedule.composeview.timepicker
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.absoluteValue
+
+@Stable
+interface TimePickerToggleState {
+    val selectedIndex: Float
+    val textColors: List<Color>
+
+    fun selectOption(scope: CoroutineScope, index: Int)
+}
+
+@Stable
+class TimePickerToggleStateImpl(
+    options: List<String>,
+    selectedOption: String,
+    private val selectedColor: Color,
+    private val unselectedColor: Color
+) : TimePickerToggleState {
+
+    override val selectedIndex: Float
+        get() = _selectedIndex.value
+
+    override val textColors: List<Color>
+        get() = _textColors.value
+
+    private var _selectedIndex = Animatable(options.indexOf(selectedOption).toFloat())
+
+    private val animationSpec = tween<Float>(
+        durationMillis = 200,
+        easing = FastOutSlowInEasing
+    )
+
+    private var _textColors: State<List<Color>> = derivedStateOf {
+        List(numOptions) { index ->
+            lerp(
+                start = unselectedColor,
+                stop = selectedColor,
+                fraction = 1f - (((selectedIndex - index.toFloat()).absoluteValue).coerceAtMost(1f))
+            )
+        }
+    }
+
+    private val numOptions = options.size
+
+    override fun selectOption(scope: CoroutineScope, index: Int) {
+        scope.launch {
+            _selectedIndex.animateTo(
+                targetValue = index.toFloat(),
+                animationSpec = animationSpec
+            )
+        }
+    }
+}
+
+@Composable
+fun rememberTimePickerToggleState(
+    options: List<String>,
+    selectedOption: String,
+    selectedColor: Color,
+    unselectedColor: Color
+) = remember {
+    TimePickerToggleStateImpl(
+        options,
+        selectedOption,
+        selectedColor,
+        unselectedColor
+    )
+}


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Related: #72

## Changes
- `TimePickerDialog`에 추가할 `TimePickerToggle` 추가
---
[ TimePickerToggle State 추가 ]
- 매개변수 : `Toggle`에 들어갈 `options`, 선택됐는지 확인할 `selectedOption`, 선택시 변경될 `text` 색상
- `options`에서 `selectedOption`의 `index`를 확인해 `selectedIndex`를 구함 
--> `TimePickerToggle`에서 `backgroundPlaceable.palceRelative`의 `x`값을 `selectedIndex * optionWidth로 변경`
--> 선택할 때 마다 `layoutId = background`의 위치가 변경됨
- `selectOption` 함수 : `TimePickerToggle`에서 `selectedOption` 변경 시 `Animation` 추가

## Screenshots
<img src="https://user-images.githubusercontent.com/84635035/169660750-0f2c2048-1a12-4ee3-8afa-de5729887b7a.gif" width=350 />
<img src="https://user-images.githubusercontent.com/84635035/169777765-224dc081-1b2d-488f-919e-faead88b99ca.gif" width=350 />

## etc
[ 고민 ]
- `TimePicker`에 `StartTime`, `EndTime`을 선택할 수 있는 버튼을 추가하려했습니다.
- `Toggle Button`처럼 만들려 하다가 `StartTime`, `EndTime`이 길이의 절반을 가져갔으면 했습니다.
- `modifier.width`로 할까하다가 화면 크기에 대응할 수 있게 만들고 싶었습니다.

[해결]
- https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
- 위 출처를 통해 `Layout`을 사용하여 요소가 측정되고 배치되는 방식을 수정할 수 있다는 것을 알게됐습니다.
- 측정하는 단계에서 안에 들어가는 버튼의 크기를 최대 너비에서 나눠 구하는 방식으로 화면에 대응이 가능합니다.
---
클릭 시 처리할 부분들도 출처를 참고해 완성한 다음 정리해서 이후 PR에 올리겠습니다!