### PR TITLE
Add Schedule 버튼 클릭 -> 일정 추가

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -14,6 +14,7 @@ import com.wap.storemanagement.utils.toDate
 import com.wap.storemanagement.utils.toLocalDateTime
 import com.wap.storemanagement.utils.toScheduleDate
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -62,5 +63,8 @@ class ScheduleViewModel @Inject constructor(
 
     fun closeDialog() {
         _isShowTimePicker.value = false
+    }
+
+    fun addDateSchedule(hour: String, minute: String) {
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -9,7 +9,6 @@ import com.wap.base.BaseViewModel
 import com.wap.base.provider.DispatcherProvider
 import com.wap.data.repository.ScheduleRepository
 import com.wap.domain.entity.Schedule
-import com.wap.domain.entity.WeekType
 import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.utils.toDate
 import com.wap.storemanagement.utils.toLocalDateTime
@@ -51,8 +50,7 @@ class ScheduleViewModel @Inject constructor(
         scheduleRepository.saveCurrentDateSchedules(currentDataSchedules.value ?: emptyList())
     }
 
-
-    fun getCurrentDateSchedules() : List<Schedule> {
+    fun getCurrentDateSchedules(): List<Schedule> {
         _currentDateSchedules.value = scheduleRepository.currentDateSchedules
         return currentDataSchedules.value ?: emptyList()
     }

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -70,22 +70,22 @@ class ScheduleViewModel @Inject constructor(
         _isShowTimePicker.value = false
     }
 
-    fun addDateSchedule(hour: Int, minute: Int) {
+    fun addDateSchedule(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
         val schedule = Schedule(
             scheduleId = 5,
             startTime = LocalDateTime.of(
                 currentDate.year,
                 currentDate.month,
                 currentDate.dayOfMonth,
-                hour,
-                minute
+                startHour,
+                startMinute
             ),
             endTime = LocalDateTime.of(
                 currentDate.year,
                 currentDate.month,
                 currentDate.dayOfMonth,
-                hour,
-                minute
+                endHour,
+                endMinute
             ),
             color = "",
             recurWeek = null,

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -9,6 +9,7 @@ import com.wap.base.BaseViewModel
 import com.wap.base.provider.DispatcherProvider
 import com.wap.data.repository.ScheduleRepository
 import com.wap.domain.entity.Schedule
+import com.wap.domain.entity.WeekType
 import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.utils.toDate
 import com.wap.storemanagement.utils.toLocalDateTime
@@ -50,7 +51,11 @@ class ScheduleViewModel @Inject constructor(
         scheduleRepository.saveCurrentDateSchedules(currentDataSchedules.value ?: emptyList())
     }
 
-    fun getCurrentDateSchedules() = scheduleRepository.currentDateSchedules
+
+    fun getCurrentDateSchedules() : List<Schedule> {
+        _currentDateSchedules.value = scheduleRepository.currentDateSchedules
+        return currentDataSchedules.value ?: emptyList()
+    }
 
     private fun saveCurrentDate() = scheduleRepository.saveCurrentDate(currentDate)
 
@@ -65,6 +70,27 @@ class ScheduleViewModel @Inject constructor(
         _isShowTimePicker.value = false
     }
 
-    fun addDateSchedule(hour: String, minute: String) {
+    fun addDateSchedule(hour: Int, minute: Int) {
+        val schedule = Schedule(
+            scheduleId = 5,
+            startTime = LocalDateTime.of(
+                currentDate.year,
+                currentDate.month,
+                currentDate.dayOfMonth,
+                hour,
+                minute
+            ),
+            endTime = LocalDateTime.of(
+                currentDate.year,
+                currentDate.month,
+                currentDate.dayOfMonth,
+                hour,
+                minute
+            ),
+            color = "",
+            recurWeek = null,
+            userId = 1L
+        )
+        _currentDateSchedules.value = _currentDateSchedules.value?.plus(schedule) ?: listOf(schedule)
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -30,6 +30,10 @@ class ScheduleViewModel @Inject constructor(
     var currentDate = scheduleRepository.currentDate
         private set
 
+    init {
+        setCurrentDateSchedules()
+    }
+
     fun fetchSchedules(date: CalendarDay) {
         _schedules.value = FakeFactory.createSchedules()
         // _schedules.value = scheduleRepository.findSchedulesByStartTime(date.toLocalDateTime())
@@ -50,9 +54,8 @@ class ScheduleViewModel @Inject constructor(
         scheduleRepository.saveCurrentDateSchedules(currentDataSchedules.value ?: emptyList())
     }
 
-    fun getCurrentDateSchedules(): List<Schedule> {
+    private fun setCurrentDateSchedules() {
         _currentDateSchedules.value = scheduleRepository.currentDateSchedules
-        return currentDataSchedules.value ?: emptyList()
     }
 
     private fun saveCurrentDate() = scheduleRepository.saveCurrentDate(currentDate)

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -66,8 +66,8 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
                 TimePickerView(
                     showDialog = isShowTimePicker,
                     onDismiss = { scheduleViewModel.closeDialog() },
-                    addSchedule = { hour, minute ->
-                        scheduleViewModel.addDateSchedule(hour, minute)
+                    addSchedule = { startHour, startMinute, endHour, endMinute ->
+                        scheduleViewModel.addDateSchedule(startHour, startMinute, endHour, endMinute)
                         scheduleViewModel.closeDialog()
                     }
                 )

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -23,7 +23,10 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
 
         binding.composeScheduleTopAppbar.setContent { AddEditScheduleTopAppBar() }
         setCheckDateView()
+
         setScrollScheduleView()
+        fetchScrollScheduleView()
+
         binding.composeScheduleSaveButton.setContent { SaveButton() }
         setTimePickerView()
     }
@@ -45,6 +48,18 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
         }
     }
 
+    private fun fetchScrollScheduleView() {
+        scheduleViewModel.currentDataSchedules.observe(this) { schedules ->
+            binding.composeScheduleScrollSchedule.setContent {
+                ScheduleView(
+                    schedules = schedules
+                ) {
+                    scheduleViewModel.showDialog()
+                }
+            }
+        }
+    }
+
     private fun setTimePickerView() {
         scheduleViewModel.isShowTimePicker.observe(this) { isShowTimePicker ->
             binding.composeScheduleTimePicker.setContent {
@@ -53,6 +68,7 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
                     onDismiss = { scheduleViewModel.closeDialog() },
                     addSchedule = { hour, minute ->
                         scheduleViewModel.addDateSchedule(hour, minute)
+                        scheduleViewModel.closeDialog()
                     }
                 )
             }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -48,9 +48,13 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
     private fun setTimePickerView() {
         scheduleViewModel.isShowTimePicker.observe(this) { isShowTimePicker ->
             binding.composeScheduleTimePicker.setContent {
-                TimePickerView(isShowTimePicker) {
-                    scheduleViewModel.closeDialog()
-                }
+                TimePickerView(
+                    showDialog = isShowTimePicker,
+                    onDismiss = { scheduleViewModel.closeDialog() },
+                    addSchedule = { hour, minute ->
+                        scheduleViewModel.addDateSchedule(hour, minute)
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -23,7 +23,6 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
 
         binding.composeScheduleTopAppbar.setContent { AddEditScheduleTopAppBar() }
         setCheckDateView()
-
         setScrollScheduleView()
         fetchScrollScheduleView()
 
@@ -41,7 +40,7 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
         binding.composeScheduleScrollSchedule.setContent {
             // ScheduleView(schedules = FakeFactory.createSchedules())
             ScheduleView(
-                schedules = scheduleViewModel.getCurrentDateSchedules()
+                schedules = scheduleViewModel.currentDataSchedules.value ?: emptyList()
             ) {
                 scheduleViewModel.showDialog()
             }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/Button.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/Button.kt
@@ -1,0 +1,51 @@
+package com.wap.storemanagement.ui.schedule.composeview.timepicker
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.wap.storemanagement.R
+
+@Composable
+fun CancelAddButton(
+    cancelEvent: () -> Unit,
+    addEvent: () -> Unit
+) {
+    val cancelText = stringResource(id = R.string.schedule_time_picker_cancel_button)
+    val addText = stringResource(id = R.string.schedule_time_picker_add_button)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(0.4f)
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .clickable { cancelEvent() },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = cancelText
+            )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .clickable { addEvent() },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = addText
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
@@ -1,0 +1,159 @@
+package com.wap.storemanagement.ui.schedule.composeview.timepicker
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wap.storemanagement.R
+import com.wap.storemanagement.fake.FakeFactory
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+fun P() {
+    val schedule = FakeFactory.createSchedules()[1]
+    val hour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
+    val minute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
+    val ampm = remember{ mutableStateOf(timeOption.AM)}
+
+    InputTime(hour, minute, ampm)
+}
+
+enum class timeOption {
+    AM,
+    PM
+}
+
+@Composable
+fun InputTime(
+    hour: MutableState<String>,
+    minute: MutableState<String>,
+    ampm: MutableState<timeOption>
+) {
+    val timeFontSize = 22.sp
+    val buttonFontSize = 16.sp
+    val focusedColor = colorResource(id = R.color.focused_indicator_color)
+    val unfocusedColor = colorResource(id = R.color.gray)
+    val borderWidth = dimensionResource(id = R.dimen.profile_border)
+    val amText = stringResource(id = R.string.schedule_time_picker_am)
+    val pmText = stringResource(id = R.string.schedule_time_picker_pm)
+    val weight = listOf(4f, 1f, 4f, 3f)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(0.8f)
+            .fillMaxHeight(0.3f),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        OutlinedTextField(
+            value = hour.value,
+            onValueChange = {
+                if (it.length in 0..2) hour.value = it
+            },
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = focusedColor,
+                unfocusedBorderColor = unfocusedColor
+            ),
+            textStyle = TextStyle(
+                fontSize = timeFontSize,
+                textAlign = TextAlign.Center
+            ),
+            maxLines = 1,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier
+                .weight(weight[0])
+                .fillMaxHeight()
+        )
+        Text(
+            text = ":",
+            modifier = Modifier.weight(weight[1]),
+            fontSize = timeFontSize,
+            textAlign = TextAlign.Center
+        )
+        OutlinedTextField(
+            value = minute.value,
+            onValueChange = {
+                if (it.length in 0..2) minute.value = it
+            },
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = focusedColor,
+                unfocusedBorderColor = unfocusedColor
+            ),
+            textStyle = TextStyle(
+                fontSize = timeFontSize,
+                textAlign = TextAlign.Center
+            ),
+            maxLines = 1,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier
+                .weight(weight[2])
+                .fillMaxHeight()
+        )
+        Column(
+            modifier = Modifier
+                .weight(weight[3])
+                .fillMaxHeight()
+            ,
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .clickable { ampm.value = timeOption.AM }
+                    .border(
+                        width = 2.dp,
+                        color = if (ampm.value == timeOption.AM) focusedColor else Color.Transparent,
+                        shape = RoundedCornerShape(10)
+                    )
+                    .fillMaxWidth(0.8f)
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = amText,
+                    fontSize = buttonFontSize
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .clickable { ampm.value = timeOption.PM }
+                    .border(
+                        width = borderWidth,
+                        color = if (ampm.value == timeOption.PM) focusedColor else Color.Transparent,
+                        shape = RoundedCornerShape(10)
+                    )
+                    .fillMaxWidth(0.8f)
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = pmText,
+                    fontSize = buttonFontSize
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
@@ -36,12 +36,12 @@ private fun PeviewInputTime() {
     val schedule = FakeFactory.createSchedules()[1]
     val hour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
     val minute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
-    val ampm = remember { mutableStateOf(timeOption.AM) }
+    val ampm = remember { mutableStateOf(TimeOption.AM) }
 
     InputTime(hour, minute, ampm)
 }
 
-enum class timeOption {
+enum class TimeOption {
     AM,
     PM
 }
@@ -50,7 +50,7 @@ enum class timeOption {
 fun InputTime(
     hour: MutableState<String>,
     minute: MutableState<String>,
-    ampm: MutableState<timeOption>
+    timeOption: MutableState<TimeOption>
 ) {
     val timeFontSize = 22.sp
     val buttonFontSize = 16.sp
@@ -121,10 +121,10 @@ fun InputTime(
         ) {
             Box(
                 modifier = Modifier
-                    .clickable { ampm.value = timeOption.AM }
+                    .clickable { timeOption.value = TimeOption.AM }
                     .border(
                         width = 2.dp,
-                        color = if (ampm.value == timeOption.AM) focusedColor else Color.Transparent,
+                        color = if (timeOption.value == TimeOption.AM) focusedColor else Color.Transparent,
                         shape = RoundedCornerShape(10)
                     )
                     .fillMaxWidth(0.8f)
@@ -138,10 +138,10 @@ fun InputTime(
             }
             Box(
                 modifier = Modifier
-                    .clickable { ampm.value = timeOption.PM }
+                    .clickable { timeOption.value = TimeOption.PM }
                     .border(
                         width = borderWidth,
-                        color = if (ampm.value == timeOption.PM) focusedColor else Color.Transparent,
+                        color = if (timeOption.value == TimeOption.PM) focusedColor else Color.Transparent,
                         shape = RoundedCornerShape(10)
                     )
                     .fillMaxWidth(0.8f)

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/InputTime.kt
@@ -32,11 +32,11 @@ import com.wap.storemanagement.fake.FakeFactory
 @RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
-fun P() {
+private fun PeviewInputTime() {
     val schedule = FakeFactory.createSchedules()[1]
     val hour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
-    val minute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
-    val ampm = remember{ mutableStateOf(timeOption.AM)}
+    val minute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
+    val ampm = remember { mutableStateOf(timeOption.AM) }
 
     InputTime(hour, minute, ampm)
 }
@@ -115,8 +115,7 @@ fun InputTime(
         Column(
             modifier = Modifier
                 .weight(weight[3])
-                .fillMaxHeight()
-            ,
+                .fillMaxHeight(),
             horizontalAlignment = Alignment.End,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -31,12 +31,12 @@ fun TimePickerView(
         val schedule = FakeFactory.createSchedules()[1]
 
         val startHour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
-        val startMinute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
-        val startAmPm = remember{ mutableStateOf(timeOption.AM)}
+        val startMinute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
+        val startAmPm = remember { mutableStateOf(timeOption.AM) }
 
         val endHour = remember { mutableStateOf(schedule.endTime.hour.toString()) }
-        val endMinute = remember{ mutableStateOf(schedule.endTime.minute.toString()) }
-        val endAmPm = remember{ mutableStateOf(timeOption.AM)}
+        val endMinute = remember { mutableStateOf(schedule.endTime.minute.toString()) }
+        val endAmPm = remember { mutableStateOf(timeOption.AM) }
 
         Dialog(
             onDismissRequest = { }
@@ -52,14 +52,14 @@ fun TimePickerView(
                 TimePickerToggle(
                     roundedCornerPercent = roundedCornerPercent,
                     options = options,
-                    selectedOption = selectedOption.value,
+                    selectedOption = selectedOption.value
                 ) { option ->
                     selectedOption.value = option
                 }
                 InputTime(
                     hour = if(selectedOption.value == "StartTime") startHour else endHour,
                     minute = if(selectedOption.value == "StartTime") startMinute else endMinute,
-                    ampm = if(selectedOption.value == "StartTime") startAmPm else endAmPm,
+                    ampm = if(selectedOption.value == "StartTime") startAmPm else endAmPm
                 )
                 CancelAddButton(
                     cancelEvent = { onDismiss() },

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -3,23 +3,17 @@ package com.wap.storemanagement.ui.schedule.composeview.timepicker
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.wap.storemanagement.R
 import com.wap.storemanagement.fake.FakeFactory
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -27,7 +21,7 @@ import com.wap.storemanagement.fake.FakeFactory
 fun TimePickerView(
     showDialog: Boolean,
     onDismiss: () -> Unit,
-    addSchedule: (hour: Int,minute: Int) -> Unit
+    addSchedule: (startHour: Int, StartMinute: Int, EndHour: Int, EndMinute: Int) -> Unit
 ) {
     if (showDialog) {
         val options: List<String> = listOf("StartTime", "EndTime")
@@ -35,9 +29,14 @@ fun TimePickerView(
         val roundedCornerPercent = 50
 
         val schedule = FakeFactory.createSchedules()[1]
-        val hour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
-        val minute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
-        val ampm = remember{ mutableStateOf(timeOption.AM)}
+
+        val startHour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
+        val startMinute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
+        val startAmPm = remember{ mutableStateOf(timeOption.AM)}
+
+        val endHour = remember { mutableStateOf(schedule.endTime.hour.toString()) }
+        val endMinute = remember{ mutableStateOf(schedule.endTime.minute.toString()) }
+        val endAmPm = remember{ mutableStateOf(timeOption.AM)}
 
         Dialog(
             onDismissRequest = { }
@@ -58,17 +57,33 @@ fun TimePickerView(
                     selectedOption.value = option
                 }
                 InputTime(
-                    hour = hour,
-                    minute = minute,
-                    ampm = ampm
+                    hour = if(selectedOption.value == "StartTime") startHour else endHour,
+                    minute = if(selectedOption.value == "StartTime") startMinute else endMinute,
+                    ampm = if(selectedOption.value == "StartTime") startAmPm else endAmPm,
                 )
                 CancelAddButton(
                     cancelEvent = { onDismiss() },
                     addEvent = {
-                        addSchedule(hour.value.toInt(), minute.value.toInt())
+                        addSchedule(
+                            hourConvert(
+                                option = startAmPm.value,
+                                hour = startHour.value
+                            ),
+                            startMinute.value.toInt(),
+                            hourConvert(
+                                option = endAmPm.value,
+                                hour = endHour.value
+                            ),
+                            endMinute.value.toInt()
+                        )
                     }
                 )
             }
         }
     }
+}
+
+private fun hourConvert(option: timeOption, hour: String) = when {
+    option == timeOption.AM -> hour.toInt()
+    else -> hour.toInt() + 12
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -83,7 +83,7 @@ fun TimePickerView(
     }
 }
 
-private fun hourConvert(option: timeOption, hour: String) = when {
-    option == timeOption.AM -> hour.toInt()
+private fun hourConvert(option: timeOption, hour: String) = when (option) {
+    timeOption.AM -> hour.toInt()
     else -> hour.toInt() + 12
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -57,9 +57,9 @@ fun TimePickerView(
                     selectedOption.value = option
                 }
                 InputTime(
-                    hour = if(selectedOption.value == "StartTime") startHour else endHour,
-                    minute = if(selectedOption.value == "StartTime") startMinute else endMinute,
-                    ampm = if(selectedOption.value == "StartTime") startAmPm else endAmPm
+                    hour = if (selectedOption.value == "StartTime") startHour else endHour,
+                    minute = if (selectedOption.value == "StartTime") startMinute else endMinute,
+                    ampm = if (selectedOption.value == "StartTime") startAmPm else endAmPm
                 )
                 CancelAddButton(
                     cancelEvent = { onDismiss() },

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -16,6 +16,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.wap.storemanagement.fake.FakeFactory
 
+enum class TimeTitle() {
+    StartTime,
+    EndTime
+}
+
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TimePickerView(
@@ -24,19 +29,20 @@ fun TimePickerView(
     addSchedule: (startHour: Int, StartMinute: Int, EndHour: Int, EndMinute: Int) -> Unit
 ) {
     if (showDialog) {
-        val options: List<String> = listOf("StartTime", "EndTime")
-        val selectedOption = remember { mutableStateOf(options.first()) }
+        val options = TimeTitle.values()
+        // val options: List<String> = listOf("StartTime", "EndTime")
+        val selectedOption = remember { mutableStateOf(TimeTitle.StartTime) }
         val roundedCornerPercent = 50
 
         val schedule = FakeFactory.createSchedules()[1]
 
         val startHour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
         val startMinute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
-        val startAmPm = remember { mutableStateOf(timeOption.AM) }
+        val startAmPm = remember { mutableStateOf(TimeOption.AM) }
 
         val endHour = remember { mutableStateOf(schedule.endTime.hour.toString()) }
         val endMinute = remember { mutableStateOf(schedule.endTime.minute.toString()) }
-        val endAmPm = remember { mutableStateOf(timeOption.AM) }
+        val endAmPm = remember { mutableStateOf(TimeOption.AM) }
 
         Dialog(
             onDismissRequest = { }
@@ -57,9 +63,9 @@ fun TimePickerView(
                     selectedOption.value = option
                 }
                 InputTime(
-                    hour = if (selectedOption.value == "StartTime") startHour else endHour,
-                    minute = if (selectedOption.value == "StartTime") startMinute else endMinute,
-                    ampm = if (selectedOption.value == "StartTime") startAmPm else endAmPm
+                    hour = if (selectedOption.value == TimeTitle.StartTime) startHour else endHour,
+                    minute = if (selectedOption.value == TimeTitle.StartTime) startMinute else endMinute,
+                    timeOption = if (selectedOption.value == TimeTitle.StartTime) startAmPm else endAmPm
                 )
                 CancelAddButton(
                     cancelEvent = { onDismiss() },
@@ -83,7 +89,7 @@ fun TimePickerView(
     }
 }
 
-private fun hourConvert(option: timeOption, hour: String) = when (option) {
-    timeOption.AM -> hour.toInt()
+private fun hourConvert(option: TimeOption, hour: String) = when (option) {
+    TimeOption.AM -> hour.toInt()
     else -> hour.toInt() + 12
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -27,7 +27,7 @@ import com.wap.storemanagement.fake.FakeFactory
 fun TimePickerView(
     showDialog: Boolean,
     onDismiss: () -> Unit,
-    addSchedule: (String, String) -> Unit
+    addSchedule: (hour: Int,minute: Int) -> Unit
 ) {
     if (showDialog) {
         val options: List<String> = listOf("StartTime", "EndTime")
@@ -65,7 +65,7 @@ fun TimePickerView(
                 CancelAddButton(
                     cancelEvent = { onDismiss() },
                     addEvent = {
-                        addSchedule(hour.toString(), minute.toString())
+                        addSchedule(hour.value.toInt(), minute.value.toInt())
                     }
                 )
             }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -1,37 +1,54 @@
 package com.wap.storemanagement.ui.schedule.composeview.timepicker
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.wap.storemanagement.R
+import com.wap.storemanagement.fake.FakeFactory
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TimePickerView(
     showDialog: Boolean,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    addSchedule: (String, String) -> Unit
 ) {
     if (showDialog) {
         val options: List<String> = listOf("StartTime", "EndTime")
         val selectedOption = remember { mutableStateOf(options.first()) }
         val roundedCornerPercent = 50
 
+        val schedule = FakeFactory.createSchedules()[1]
+        val hour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
+        val minute = remember{ mutableStateOf(schedule.startTime.minute.toString()) }
+        val ampm = remember{ mutableStateOf(timeOption.AM)}
+
         Dialog(
-            onDismissRequest = { onDismiss() }
+            onDismissRequest = { }
         ) {
             Column(
                 Modifier
-                    .size(280.dp, 260.dp)
+                    .size(280.dp, 240.dp)
                     .clip(shape = RoundedCornerShape(roundedCornerPercent / 4))
                     .background(Color.White),
-                verticalArrangement = Arrangement.SpaceBetween
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 TimePickerToggle(
                     roundedCornerPercent = roundedCornerPercent,
@@ -40,10 +57,17 @@ fun TimePickerView(
                 ) { option ->
                     selectedOption.value = option
                 }
-                Row() {
-                    Text(text = "취소")
-                    Text(text = "확인")
-                }
+                InputTime(
+                    hour = hour,
+                    minute = minute,
+                    ampm = ampm
+                )
+                CancelAddButton(
+                    cancelEvent = { onDismiss() },
+                    addEvent = {
+                        addSchedule(hour.toString(), minute.toString())
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
@@ -4,22 +4,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import com.wap.storemanagement.R
@@ -32,9 +27,9 @@ private enum class TimePickerToggleOption {
 // 출처: https://fvilarino.medium.com/creating-an-animated-selector-in-jetpack-compose-669066dfc01b
 @Composable
 fun TimePickerToggle(
-    options: List<String>,
+    options: Array<TimeTitle>,
     roundedCornerPercent: Int,
-    selectedOption: String,
+    selectedOption: TimeTitle,
     selectedColor: Color = Color.White,
     unselectedColor: Color = colorResource(id = R.color.gray_text),
     state: TimePickerToggleState = rememberTimePickerToggleState(
@@ -43,7 +38,7 @@ fun TimePickerToggle(
         selectedColor = selectedColor,
         unselectedColor = unselectedColor
     ),
-    onOptionSelect: (String) -> Unit,
+    onOptionSelect: (TimeTitle) -> Unit,
 ) {
     val backgroundColor = colorResource(id = R.color.focused_indicator_color)
 
@@ -66,7 +61,7 @@ fun TimePickerToggle(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = option,
+                        text = option.name,
                         style = MaterialTheme.typography.body1,
                         color = colors[index],
                         modifier = Modifier.padding(horizontal = 4.dp),
@@ -114,20 +109,5 @@ fun TimePickerToggle(
                 )
             }
         }
-    }
-}
-
-@Preview(widthDp = 190, heightDp = 300)
-@Composable
-private fun PreviewTimePicker() {
-    val options: List<String> = listOf("StartTime", "EndTime")
-    val selectedOption = remember { mutableStateOf(options.first()) }
-
-    TimePickerToggle(
-        options = options,
-        roundedCornerPercent = 50,
-        selectedOption = selectedOption.value
-    ) { option ->
-        selectedOption.value = option
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggle.kt
@@ -55,7 +55,6 @@ fun TimePickerToggle(
 
     Layout(
         modifier = Modifier
-            .clip(shape = RoundedCornerShape(roundedCornerPercent))
             .background(color = Color.White),
         content = {
             val colors = state.textColors
@@ -78,7 +77,6 @@ fun TimePickerToggle(
                 Box(
                     modifier = Modifier
                         .layoutId(TimePickerToggleOption.Background)
-                        .clip(shape = RoundedCornerShape(roundedCornerPercent))
                         .background(backgroundColor)
                 )
             }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggleState.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePickerToggleState.kt
@@ -20,8 +20,8 @@ interface TimePickerToggleState {
 
 @Stable
 class TimePickerToggleStateImpl(
-    options: List<String>,
-    selectedOption: String,
+    options: Array<TimeTitle>,
+    selectedOption: TimeTitle,
     private val selectedColor: Color,
     private val unselectedColor: Color
 ) : TimePickerToggleState {
@@ -63,8 +63,8 @@ class TimePickerToggleStateImpl(
 
 @Composable
 fun rememberTimePickerToggleState(
-    options: List<String>,
-    selectedOption: String,
+    options: Array<TimeTitle>,
+    selectedOption: TimeTitle,
     selectedColor: Color,
     unselectedColor: Color
 ) = remember {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="schedule_schedule_card_end_text">종료</string>
     <string name="schedule_time_picker_am">오전</string>
     <string name="schedule_time_picker_pm">오후</string>
+    <string name="schedule_time_picker_cancel_button">취소</string>
+    <string name="schedule_time_picker_add_button">확인</string>
 
     <string name="set_calender_top_appbar_title">시간표 설정</string>
     <string name="set_calender_name_sub_title">시간표 이름</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="schedule_add_card_text">Add Schedule</string>
     <string name="schedule_schedule_card_start_text">시작</string>
     <string name="schedule_schedule_card_end_text">종료</string>
+    <string name="schedule_time_picker_am">오전</string>
+    <string name="schedule_time_picker_pm">오후</string>
 
     <string name="set_calender_top_appbar_title">시간표 설정</string>
     <string name="set_calender_name_sub_title">시간표 이름</string>


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #72

## Changes
- `Time Picker View` : `inputTime`, `cancel, add button` 추가
- `add button` 클릭 시 `timePicker`에서 시간정보를 반환한다.
- `addDateSchedule` 함수 : 받은 시간정보를 `schedule`로 만들어 `_currentDateSchedules`에 추가해준다.
- `getCurrentDateSchedule` 함수 : `view`에서는 `fragment`에서 넘겨온 `list`를 받지만 `viewModel`에서는 알지 못해서 `viewModel`에 있는 `currentDataSchedules`에 `value`를 넣어주는 코드를 추가
- `fetchScrollScheduleView` 함수 : `currentDataSchedules`를 `observe`해 변경되면 `view`를 교체해준다.

## Screenshots
<img src="https://user-images.githubusercontent.com/84635035/170289181-ccb37bd3-0958-4309-a0d6-a1fcfb2ed4eb.gif" width=350 />

## etc
- `ScheduleViewModel`에서 `addDateSchedule`을 할 때 `scheduleId`를 어떻게 받을지 생각이 안나네요,.,
- `scheduleId`를 `data class Schedule`에서 빼보려했는데 `lazyColumn`에서 `schedule.schedulId`를 `key`값으로 사용을 해서 빼기 어려울 것 같습니다.
-> 지금은 확인용으로 `addDateSchedule` 함수에 `scheduleId`값을 직접 넣어둬서 일정은 하나만 추가 가능 합니다