### PR TITLE
scheduleId 중복으로 발생하는 addSchedule문제 해결

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/MainActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/MainActivity.kt
@@ -19,6 +19,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     }
 
     private fun setNavHostFragment() {
-        binding.bottomBarMain.setupWithNavController(navController)
+        binding.bottomNavigationMain.setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/fake/FakeFactory.kt
+++ b/app/src/main/java/com/wap/storemanagement/fake/FakeFactory.kt
@@ -11,7 +11,6 @@ object FakeFactory {
 
     fun createSchedules() = listOf(
         Schedule(
-            scheduleId = 0L,
             startTime = LocalDateTime.of(2022, 5, 5, 12, 0),
             endTime = LocalDateTime.of(2022, 5, 5, 13, 0),
             color = "",
@@ -19,7 +18,6 @@ object FakeFactory {
             userId = 1L
         ),
         Schedule(
-            scheduleId = 1L,
             startTime = LocalDateTime.of(2022, 5, 6, 15, 0),
             endTime = LocalDateTime.of(2022, 5, 6, 17, 0),
             color = "",

--- a/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.wap.domain.entity.Schedule
 import com.wap.storemanagement.R
 import java.time.LocalTime
 
@@ -123,3 +124,12 @@ private fun BaseSurface(block: @Composable () -> Unit) {
         block()
     }
 }
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun Schedule.keyForScheduleLazyColumn(): String {
+    val startTime = this.startTime.toString()
+    val endTime = this.endTime.toLocalTime().toString()
+
+    return startTime + endTime
+}
+

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -73,7 +73,6 @@ class ScheduleViewModel @Inject constructor(
 
     fun addDateSchedule(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
         val schedule = Schedule(
-            scheduleId = 5,
             startTime = LocalDateTime.of(
                 currentDate.year,
                 currentDate.month,

--- a/app/src/main/java/com/wap/storemanagement/ui/home/composeview/MyScheduleView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/composeview/MyScheduleView.kt
@@ -24,6 +24,7 @@ import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.ui.basecomposeview.BaseScheduleLazyColumn
 import com.wap.storemanagement.ui.basecomposeview.Profile
 import com.wap.storemanagement.ui.basecomposeview.formatToString
+import com.wap.storemanagement.ui.basecomposeview.keyForScheduleLazyColumn
 import java.time.LocalTime
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -33,7 +34,7 @@ fun ScheduleCards(schedules: List<Schedule>, onClick: () -> Unit) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
-            key = { schedule -> schedule.scheduleId }
+            key = { schedule -> schedule.keyForScheduleLazyColumn() }
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
@@ -15,6 +15,7 @@ import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.ui.basecomposeview.AddScheduleCard
 import com.wap.storemanagement.ui.basecomposeview.BaseScheduleLazyColumn
 import com.wap.storemanagement.ui.basecomposeview.ScheduleCard
+import com.wap.storemanagement.ui.basecomposeview.keyForScheduleLazyColumn
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -23,7 +24,7 @@ fun ScheduleView(schedules: List<Schedule>, onClickAdd: () -> Unit) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
-            key = { schedule -> schedule.scheduleId }
+            key = { schedule -> schedule.keyForScheduleLazyColumn() }
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()

--- a/app/src/main/java/com/wap/storemanagement/ui/set/composeview/FixedSchedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/set/composeview/FixedSchedule.kt
@@ -25,10 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.wap.domain.entity.Schedule
 import com.wap.domain.entity.WeekType
 import com.wap.storemanagement.R
-import com.wap.storemanagement.ui.basecomposeview.AddScheduleCard
-import com.wap.storemanagement.ui.basecomposeview.BaseScheduleLazyColumn
-import com.wap.storemanagement.ui.basecomposeview.ScheduleCard
-import com.wap.storemanagement.ui.basecomposeview.SubTitle
+import com.wap.storemanagement.ui.basecomposeview.*
 
 @Composable
 fun CalendarFixedScheduleTitle() {
@@ -65,7 +62,7 @@ fun SelectedRecurSchedules(schedules: List<Schedule>, onClickAdd: () -> Unit) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
-            key = { schedule -> schedule.scheduleId }
+            key = { schedule -> schedule.keyForScheduleLazyColumn() }
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()

--- a/data/src/main/java/com/wap/data/Mapper.kt
+++ b/data/src/main/java/com/wap/data/Mapper.kt
@@ -11,7 +11,6 @@ import com.wap.domain.entity.Schedule
 
 @RequiresApi(Build.VERSION_CODES.O)
 fun ScheduleEntity.toSchedule() = Schedule(
-    scheduleId = scheduleId,
     startTime = toLocalDateTime(startTime),
     endTime = toLocalDateTime(endTime),
     color = color,
@@ -21,7 +20,6 @@ fun ScheduleEntity.toSchedule() = Schedule(
 
 @RequiresApi(Build.VERSION_CODES.O)
 fun Schedule.toEntity() = ScheduleEntity(
-    scheduleId = scheduleId,
     startTime = fromLocalDateTime(startTime),
     endTime = fromLocalDateTime(endTime),
     color = color,

--- a/domain/src/main/java/com/wap/domain/entity/Schedule.kt
+++ b/domain/src/main/java/com/wap/domain/entity/Schedule.kt
@@ -3,7 +3,6 @@ package com.wap.domain.entity
 import java.time.LocalDateTime
 
 data class Schedule(
-    val scheduleId: Long, // 기본키
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
     val color: String,


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #80 

## Changes
- `domain` `schedule entitiy`에 있는 `scheduleId`제거
- `lazyColumn`에서 사용하는 `key`값을 `scheduleId`에서 `startTime + endTime`으로 변경

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
<!-- 비고
- 트러블슈팅 공유, 고민 등을 서술
-->