### PR TITLE
ScheduleId 중복으로 발생하는 AddSchedule 문제 해결

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/MainActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/MainActivity.kt
@@ -19,6 +19,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     }
 
     private fun setNavHostFragment() {
-        binding.bottomBarMain.setupWithNavController(navController)
+        binding.bottomNavigationMain.setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.wap.domain.entity.Schedule
 import com.wap.storemanagement.R
 import java.time.LocalTime
 
@@ -123,3 +124,12 @@ private fun BaseSurface(block: @Composable () -> Unit) {
         block()
     }
 }
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun Schedule.keyForScheduleLazyColumn(): String {
+    val startTime = this.startTime.toString()
+    val endTime = this.endTime.toLocalTime().toString()
+
+    return startTime + endTime
+}
+

--- a/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
@@ -126,10 +126,4 @@ private fun BaseSurface(block: @Composable () -> Unit) {
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
-fun Schedule.keyForScheduleLazyColumn(): String {
-    val startTime = this.startTime.toString()
-    val endTime = this.endTime.toLocalTime().toString()
-
-    return startTime + endTime
-}
-
+fun Schedule.keyForScheduleLazyColumn(): String = startTime.toString() + endTime.toLocalTime().toString()

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -73,7 +73,7 @@ class ScheduleViewModel @Inject constructor(
 
     fun addDateSchedule(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
         val schedule = Schedule(
-            scheduleId = 5,
+            scheduleId = -1,
             startTime = LocalDateTime.of(
                 currentDate.year,
                 currentDate.month,

--- a/app/src/main/java/com/wap/storemanagement/ui/home/composeview/MyScheduleView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/composeview/MyScheduleView.kt
@@ -24,6 +24,7 @@ import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.ui.basecomposeview.BaseScheduleLazyColumn
 import com.wap.storemanagement.ui.basecomposeview.Profile
 import com.wap.storemanagement.ui.basecomposeview.formatToString
+import com.wap.storemanagement.ui.basecomposeview.keyForScheduleLazyColumn
 import java.time.LocalTime
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -33,7 +34,7 @@ fun ScheduleCards(schedules: List<Schedule>, onClick: () -> Unit) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
-            key = { schedule -> schedule.scheduleId }
+            key = { schedule -> schedule.keyForScheduleLazyColumn() }
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
@@ -15,6 +15,7 @@ import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.ui.basecomposeview.AddScheduleCard
 import com.wap.storemanagement.ui.basecomposeview.BaseScheduleLazyColumn
 import com.wap.storemanagement.ui.basecomposeview.ScheduleCard
+import com.wap.storemanagement.ui.basecomposeview.keyForScheduleLazyColumn
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -23,7 +24,7 @@ fun ScheduleView(schedules: List<Schedule>, onClickAdd: () -> Unit) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
-            key = { schedule -> schedule.scheduleId }
+            key = { schedule -> schedule.keyForScheduleLazyColumn() }
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #80 
- Resolve: #75 

## Changes
- `schedule`을 `item`으로 사용하는 `lazyColumn`에서 사용할 `key`값을 변경

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
- 처음에는 `scheduleId`를 삭제하려 했으나 이후 저장 과정에서 `DB`에 있는 `schedule`과의 비교를 위해서 있어야 한다고 생각돼서 `key`값만 변경하고 새로 생성되는 `scheduleId`는 `DB`의 `scheduleId`와 중복되지 않게 `-1`로 생성했습니다.