### PR TITLE
일정 수정 기능 추가

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/basecomposeview/Schedule.kt
@@ -39,7 +39,7 @@ fun BaseScheduleLazyColumn(block: (LazyListScope) -> Unit) {
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ScheduleCard(startTime: LocalTime, endTime: LocalTime) {
+fun ScheduleCard(startTime: LocalTime, endTime: LocalTime, onClick: () -> Unit) {
     val checkBoxColor = colorResource(id = R.color.schedule_check_box)
     val grayTextColor = colorResource(id = R.color.gray_text)
     val checkedState = remember { mutableStateOf(false) }
@@ -50,30 +50,39 @@ fun ScheduleCard(startTime: LocalTime, endTime: LocalTime) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceEvenly
         ) {
-            BaseTimeColumn {
-                Text(
-                    text = stringResource(id = R.string.schedule_schedule_card_start_text),
-                    fontSize = 18.sp,
-                    color = grayTextColor
-                )
-                Text(text = startTime.formatToString(), fontSize = 22.sp)
-            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                modifier = Modifier
+                    .weight(0.8f)
+                    .clickable { onClick() }
+            ) {
+                BaseTimeColumn {
+                    Text(
+                        text = stringResource(id = R.string.schedule_schedule_card_start_text),
+                        fontSize = 18.sp,
+                        color = grayTextColor
+                    )
+                    Text(text = startTime.formatToString(), fontSize = 22.sp)
+                }
 
-            Text(text = "-", fontSize = 22.sp)
+                Text(text = "-", fontSize = 22.sp)
 
-            BaseTimeColumn {
-                Text(
-                    text = stringResource(id = R.string.schedule_schedule_card_end_text),
-                    fontSize = 18.sp,
-                    color = grayTextColor
-                )
-                Text(text = endTime.formatToString(), fontSize = 22.sp)
+                BaseTimeColumn {
+                    Text(
+                        text = stringResource(id = R.string.schedule_schedule_card_end_text),
+                        fontSize = 18.sp,
+                        color = grayTextColor
+                    )
+                    Text(text = endTime.formatToString(), fontSize = 22.sp)
+                }
             }
 
             Checkbox(
                 checked = checkedState.value,
                 onCheckedChange = { checkedState.value = it },
-                colors = CheckboxDefaults.colors(checkBoxColor)
+                colors = CheckboxDefaults.colors(checkBoxColor),
+                modifier = Modifier.weight(0.2f)
             )
         }
     }

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -97,4 +97,34 @@ class ScheduleViewModel @Inject constructor(
         )
         _currentDateSchedules.value = _currentDateSchedules.value?.plus(schedule) ?: listOf(schedule)
     }
+
+    lateinit var scheduleForEdit: Schedule
+
+    fun editDateSchedule(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
+        val editScheduleIndex = _currentDateSchedules.value!!.indexOf(scheduleForEdit)
+        val editedSchedule = Schedule(
+            scheduleId = scheduleForEdit.scheduleId,
+            startTime = LocalDateTime.of(
+                scheduleForEdit.startTime.year,
+                scheduleForEdit.startTime.month,
+                scheduleForEdit.startTime.dayOfMonth,
+                startHour,
+                startMinute
+            ),
+            endTime = LocalDateTime.of(
+                scheduleForEdit.endTime.year,
+                scheduleForEdit.endTime.month,
+                scheduleForEdit.endTime.dayOfMonth,
+                endHour,
+                endMinute
+            ),
+            color = scheduleForEdit.color,
+            recurWeek = scheduleForEdit.recurWeek,
+            userId = scheduleForEdit.userId
+        )
+
+        _currentDateSchedules.value = _currentDateSchedules.value?.toMutableList().apply {
+            this?.set(editScheduleIndex, editedSchedule)
+        }
+    }
 }

--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -10,6 +10,7 @@ import com.wap.base.provider.DispatcherProvider
 import com.wap.data.repository.ScheduleRepository
 import com.wap.domain.entity.Schedule
 import com.wap.storemanagement.fake.FakeFactory
+import com.wap.storemanagement.ui.schedule.TimePickerState
 import com.wap.storemanagement.utils.toDate
 import com.wap.storemanagement.utils.toLocalDateTime
 import com.wap.storemanagement.utils.toScheduleDate
@@ -62,15 +63,15 @@ class ScheduleViewModel @Inject constructor(
 
     fun saveButtonEvent() = scheduleRepository.saveViewModelToDB(_currentDateSchedules.value ?: emptyList())
 
-    private var _isShowTimePicker: MutableLiveData<Boolean> = MutableLiveData(false)
-    val  isShowTimePicker: LiveData<Boolean> = _isShowTimePicker
+    private var _timePickerState: MutableLiveData<TimePickerState> = MutableLiveData(TimePickerState.Close)
+    val timePickerState: LiveData<TimePickerState> = _timePickerState
 
-    fun showDialog() {
-        _isShowTimePicker.value = true
+    fun showDialog(option: TimePickerState) {
+        _timePickerState.value = option
     }
 
     fun closeDialog() {
-        _isShowTimePicker.value = false
+        _timePickerState.value = TimePickerState.Close
     }
 
     fun addDateSchedule(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -52,7 +52,6 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
     private fun fetchScrollScheduleView() {
         scheduleViewModel.currentDataSchedules.observe(this) { schedules ->
             binding.composeScheduleScrollSchedule.setContent {
-                Log.i("fetchSchedule","${scheduleViewModel.currentDataSchedules.value}")
                 ScheduleView(
                     schedules = schedules,
                     onClickAdd = { scheduleViewModel.showDialog(TimePickerState.Add) },

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -2,13 +2,16 @@ package com.wap.storemanagement.ui.schedule
 
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
 import com.wap.base.BaseActivity
 import com.wap.storemanagement.R
 import com.wap.storemanagement.databinding.ActivityScheduleBinding
 import com.wap.storemanagement.ui.home.ScheduleViewModel
 import com.wap.storemanagement.ui.schedule.composeview.*
+import com.wap.storemanagement.ui.schedule.composeview.timepicker.Empty
 import com.wap.storemanagement.ui.schedule.composeview.timepicker.TimePickerView
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -39,37 +42,62 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
         binding.composeScheduleScrollSchedule.setContent {
             // ScheduleView(schedules = FakeFactory.createSchedules())
             ScheduleView(
-                schedules = scheduleViewModel.currentDataSchedules.value ?: emptyList()
-            ) {
-                scheduleViewModel.showDialog()
-            }
+                schedules = scheduleViewModel.currentDataSchedules.value ?: emptyList(),
+                onClickAdd = { scheduleViewModel.showDialog(TimePickerState.Add) },
+                onClickSchedule = { scheduleViewModel.showDialog(TimePickerState.Edit) }
+            )
         }
     }
 
     private fun fetchScrollScheduleView() {
         scheduleViewModel.currentDataSchedules.observe(this) { schedules ->
             binding.composeScheduleScrollSchedule.setContent {
+                Log.i("fetchSchedule","${scheduleViewModel.currentDataSchedules.value}")
                 ScheduleView(
-                    schedules = schedules
-                ) {
-                    scheduleViewModel.showDialog()
-                }
+                    schedules = schedules,
+                    onClickAdd = { scheduleViewModel.showDialog(TimePickerState.Add) },
+                    onClickSchedule = { schedule ->
+                        scheduleViewModel.showDialog(TimePickerState.Edit)
+                        scheduleViewModel.scheduleForEdit = schedule
+                    }
+                )
             }
         }
     }
 
     private fun setTimePickerView() {
-        scheduleViewModel.isShowTimePicker.observe(this) { isShowTimePicker ->
+        scheduleViewModel.timePickerState.observe(this) { state ->
             binding.composeScheduleTimePicker.setContent {
-                TimePickerView(
-                    showDialog = isShowTimePicker,
-                    onDismiss = { scheduleViewModel.closeDialog() },
-                    addSchedule = { startHour, startMinute, endHour, endMinute ->
-                        scheduleViewModel.addDateSchedule(startHour, startMinute, endHour, endMinute)
-                        scheduleViewModel.closeDialog()
-                    }
-                )
+                when (state) {
+                    TimePickerState.Close -> Empty()
+                    else -> AddEditTimePickerView(state)
+                }
             }
+        }
+    }
+
+    @Composable
+    private fun AddEditTimePickerView(state: TimePickerState) {
+        TimePickerView(
+            onDismiss = { scheduleViewModel.closeDialog() },
+            confirmEvent = { startHour, startMinute, endHour, endMinute ->
+                setConfirmEvent(state, startHour, startMinute, endHour, endMinute)
+                scheduleViewModel.closeDialog()
+            }
+        )
+    }
+
+    private fun setConfirmEvent(
+        state: TimePickerState,
+        startHour: Int,
+        startMinute: Int,
+        endHour: Int,
+        endMinute: Int
+    ) {
+        when (state) {
+            TimePickerState.Add -> scheduleViewModel.addDateSchedule(startHour, startMinute, endHour, endMinute)
+            TimePickerState.Edit -> scheduleViewModel.editDateSchedule(startHour, startMinute, endHour, endMinute)
+            else -> error("무슨 일이지?")
         }
     }
 

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/TimePickerState.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/TimePickerState.kt
@@ -1,0 +1,7 @@
+package com.wap.storemanagement.ui.schedule
+
+enum class TimePickerState {
+    Add,
+    Edit,
+    Close
+}

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/ScheduleView.kt
@@ -19,8 +19,11 @@ import com.wap.storemanagement.ui.basecomposeview.keyForScheduleLazyColumn
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun ScheduleView(schedules: List<Schedule>, onClickAdd: () -> Unit) {
-
+fun ScheduleView(
+    schedules: List<Schedule>,
+    onClickAdd: () -> Unit,
+    onClickSchedule: (Schedule) -> Unit,
+) {
     BaseScheduleLazyColumn { scope ->
         scope.items(
             items = schedules,
@@ -28,7 +31,11 @@ fun ScheduleView(schedules: List<Schedule>, onClickAdd: () -> Unit) {
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()
-            ScheduleCard(startTime = startTime, endTime = endTime)
+            ScheduleCard(
+                startTime = startTime,
+                endTime = endTime,
+                onClick = { onClickSchedule(schedule) }
+            )
         }
         scope.item { AddScheduleCard(onClick = onClickAdd) }
     }

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/Button.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/Button.kt
@@ -15,7 +15,7 @@ import com.wap.storemanagement.R
 @Composable
 fun CancelAddButton(
     cancelEvent: () -> Unit,
-    addEvent: () -> Unit
+    confirmEvent: () -> Unit
 ) {
     val cancelText = stringResource(id = R.string.schedule_time_picker_cancel_button)
     val addText = stringResource(id = R.string.schedule_time_picker_add_button)
@@ -40,7 +40,7 @@ fun CancelAddButton(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxHeight()
-                .clickable { addEvent() },
+                .clickable { confirmEvent() },
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -21,73 +21,75 @@ enum class TimeTitle() {
     EndTime
 }
 
+@Composable
+fun Empty() {
+
+}
+
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun TimePickerView(
-    showDialog: Boolean,
     onDismiss: () -> Unit,
-    addSchedule: (startHour: Int, StartMinute: Int, EndHour: Int, EndMinute: Int) -> Unit
+    confirmEvent: (startHour: Int, StartMinute: Int, EndHour: Int, EndMinute: Int) -> Unit
 ) {
-    if (showDialog) {
-        val options = TimeTitle.values()
-        // val options: List<String> = listOf("StartTime", "EndTime")
-        val selectedOption = remember { mutableStateOf(TimeTitle.StartTime) }
-        val roundedCornerPercent = 50
+    val options = TimeTitle.values()
+    val selectedOption = remember { mutableStateOf(TimeTitle.StartTime) }
+    val roundedCornerPercent = 50
 
-        val schedule = FakeFactory.createSchedules()[1]
+    val schedule = FakeFactory.createSchedules()[1]
 
-        val startHour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
-        val startMinute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
-        val startAmPm = remember { mutableStateOf(TimeOption.AM) }
+    val startHour = remember { mutableStateOf(schedule.startTime.hour.toString()) }
+    val startMinute = remember { mutableStateOf(schedule.startTime.minute.toString()) }
+    val startAmPm = remember { mutableStateOf(TimeOption.AM) }
 
-        val endHour = remember { mutableStateOf(schedule.endTime.hour.toString()) }
-        val endMinute = remember { mutableStateOf(schedule.endTime.minute.toString()) }
-        val endAmPm = remember { mutableStateOf(TimeOption.AM) }
+    val endHour = remember { mutableStateOf(schedule.endTime.hour.toString()) }
+    val endMinute = remember { mutableStateOf(schedule.endTime.minute.toString()) }
+    val endAmPm = remember { mutableStateOf(TimeOption.AM) }
 
-        Dialog(
-            onDismissRequest = { }
+    Dialog(
+        onDismissRequest = { }
+    ) {
+        Column(
+            Modifier
+                .size(280.dp, 240.dp)
+                .clip(shape = RoundedCornerShape(roundedCornerPercent / 4))
+                .background(Color.White),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(
-                Modifier
-                    .size(280.dp, 240.dp)
-                    .clip(shape = RoundedCornerShape(roundedCornerPercent / 4))
-                    .background(Color.White),
-                verticalArrangement = Arrangement.SpaceBetween,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                TimePickerToggle(
-                    roundedCornerPercent = roundedCornerPercent,
-                    options = options,
-                    selectedOption = selectedOption.value
-                ) { option ->
-                    selectedOption.value = option
-                }
-                InputTime(
-                    hour = if (selectedOption.value == TimeTitle.StartTime) startHour else endHour,
-                    minute = if (selectedOption.value == TimeTitle.StartTime) startMinute else endMinute,
-                    timeOption = if (selectedOption.value == TimeTitle.StartTime) startAmPm else endAmPm
-                )
-                CancelAddButton(
-                    cancelEvent = { onDismiss() },
-                    addEvent = {
-                        addSchedule(
-                            hourConvert(
-                                option = startAmPm.value,
-                                hour = startHour.value
-                            ),
-                            startMinute.value.toInt(),
-                            hourConvert(
-                                option = endAmPm.value,
-                                hour = endHour.value
-                            ),
-                            endMinute.value.toInt()
-                        )
-                    }
-                )
+            TimePickerToggle(
+                roundedCornerPercent = roundedCornerPercent,
+                options = options,
+                selectedOption = selectedOption.value
+            ) { option ->
+                selectedOption.value = option
             }
+            InputTime(
+                hour = if (selectedOption.value == TimeTitle.StartTime) startHour else endHour,
+                minute = if (selectedOption.value == TimeTitle.StartTime) startMinute else endMinute,
+                timeOption = if (selectedOption.value == TimeTitle.StartTime) startAmPm else endAmPm
+            )
+            CancelAddButton(
+                cancelEvent = { onDismiss() },
+                confirmEvent = {
+                    confirmEvent(
+                        hourConvert(
+                            option = startAmPm.value,
+                            hour = startHour.value
+                        ),
+                        startMinute.value.toInt(),
+                        hourConvert(
+                            option = endAmPm.value,
+                            hour = endHour.value
+                        ),
+                        endMinute.value.toInt()
+                    )
+                }
+            )
         }
     }
 }
+
 
 private fun hourConvert(option: TimeOption, hour: String) = when (option) {
     TimeOption.AM -> hour.toInt()

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/timepicker/TimePicker.kt
@@ -64,11 +64,10 @@ fun TimePickerView(
             ) { option ->
                 selectedOption.value = option
             }
-            InputTime(
-                hour = if (selectedOption.value == TimeTitle.StartTime) startHour else endHour,
-                minute = if (selectedOption.value == TimeTitle.StartTime) startMinute else endMinute,
-                timeOption = if (selectedOption.value == TimeTitle.StartTime) startAmPm else endAmPm
-            )
+            when (selectedOption.value) {
+                TimeTitle.StartTime -> InputTime(hour = startHour, minute = startMinute, timeOption = startAmPm)
+                TimeTitle.EndTime -> InputTime(hour = endHour, minute = endMinute, timeOption = endAmPm)
+            }
             CancelAddButton(
                 cancelEvent = { onDismiss() },
                 confirmEvent = {

--- a/app/src/main/java/com/wap/storemanagement/ui/set/composeview/FixedSchedule.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/set/composeview/FixedSchedule.kt
@@ -60,7 +60,11 @@ fun SelectWeek() {
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun SelectedRecurSchedules(schedules: List<Schedule>, onClickAdd: () -> Unit) {
+fun SelectedRecurSchedules(
+    schedules: List<Schedule>,
+    onClickAdd: () -> Unit,
+    onClickSchedule: (Schedule) -> Unit
+) {
 
     BaseScheduleLazyColumn { scope ->
         scope.items(
@@ -69,7 +73,11 @@ fun SelectedRecurSchedules(schedules: List<Schedule>, onClickAdd: () -> Unit) {
         ) { schedule ->
             val startTime = schedule.startTime.toLocalTime()
             val endTime = schedule.endTime.toLocalTime()
-            ScheduleCard(startTime = startTime, endTime = endTime)
+            ScheduleCard(
+                startTime = startTime,
+                endTime = endTime,
+                onClick = { onClickSchedule(schedule) }
+            )
         }
         scope.item { AddScheduleCard(onClick = onClickAdd) }
     }


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #96

## Changes
[ `ScheduleCard` ]
: `onClick` 추가, `click`시 해당`schedule` 반환 
---> `ScheduleViewModel`에 `schedule` 저장
---> `showDialog value` -> `Edit` 

---

[ `setTimePicker` ]
- `timePickerState` `Add, Edit`인 경우 `TimePickerView` `set`

---

[ `editDateSchedule` ]
- currentDateSchedules에서  저장한 `schedule`의 `index`값을 구함
- 저장한 `schedule`에서 시간만 변경한 `editedSchedule` 생성
- `currentDateSchedules.value` `index`에 있는 `schedule`을 `editedSchedule`로 변경

## Screenshots
<img src="https://user-images.githubusercontent.com/84635035/170885646-14517d4a-3a37-436d-b4e9-bd9b8bed5756.gif" width=350 />

## etc
<!-- 비고
- 트러블슈팅 공유, 고민 등을 서술
-->