### PR TITLE
findScheduleByStartDate 로직 변경

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/home/ScheduleViewModel.kt
@@ -9,7 +9,6 @@ import com.wap.base.BaseViewModel
 import com.wap.base.provider.DispatcherProvider
 import com.wap.data.repository.ScheduleRepository
 import com.wap.domain.entity.Schedule
-import com.wap.storemanagement.fake.FakeFactory
 import com.wap.storemanagement.ui.schedule.DeleteButtonState
 import com.wap.storemanagement.ui.schedule.TimePickerState
 import com.wap.storemanagement.utils.toDate
@@ -28,8 +27,6 @@ class ScheduleViewModel @Inject constructor(
 
     private var _checkedState: MutableLiveData<Int> = MutableLiveData(0)
     val checkedState: LiveData<Int> = _checkedState
-
-    private var _schedules: MutableLiveData<List<Schedule>> = MutableLiveData()
 
     private val _currentDateSchedules = MutableLiveData<List<Schedule>>()
     val currentDataSchedules: LiveData<List<Schedule>> = _currentDateSchedules
@@ -71,11 +68,14 @@ class ScheduleViewModel @Inject constructor(
         setCurrentDateSchedules()
     }
 
-    fun fetchSchedules(date: CalendarDay) {
-        _schedules.value = FakeFactory.createSchedules()
-        // _schedules.value = scheduleRepository.findSchedulesByStartTime(date.toLocalDateTime())
+    fun fetchSchedules(date: CalendarDay) = onIo {
+//        val schedules = FakeFactory.createSchedules()
+         val schedules = scheduleRepository.findSchedulesByStartTime(date.toLocalDateTime())
 
-        _currentDateSchedules.value = _schedules.value?.filter { schedule -> isCurrentDateSchedule(date, schedule) } ?: emptyList()
+        onMain {
+            _currentDateSchedules.value = schedules.filter { schedule -> isCurrentDateSchedule(date, schedule) }
+        }
+
         currentDate = date.toLocalDateTime()
     }
 

--- a/data/src/main/java/com/wap/data/db/dao/ScheduleDao.kt
+++ b/data/src/main/java/com/wap/data/db/dao/ScheduleDao.kt
@@ -16,8 +16,11 @@ interface ScheduleDao {
     @Query("SELECT * FROM SCHEDULE WHERE user_id = :userId")
     fun findSchedulesByUserId(userId: Long): List<ScheduleEntity>?
 
-    @Query("SELECT * FROM SCHEDULE WHERE startTime = :startTime")
-    fun findSchedulesByStartDate(startTime: LocalDateTime): List<ScheduleEntity>?
+    // @Query("SELECT * FROM SCHEDULE WHERE startTime = :startTime")
+    // fun findSchedulesByStartDate(startTime: LocalDateTime): List<ScheduleEntity>?
+
+    @Query("SELECT * FROM SCHEDULE WHERE startTime between :startDateMin and :startDateMax")
+    fun findSchedulesByStartDate(startDateMin: LocalDateTime, startDateMax: LocalDateTime): List<ScheduleEntity>?
 
     @Query("SELECT * FROM SCHEDULE WHERE scheduleId= :scheduleId")
     fun findScheduleByScheduleId(scheduleId: Long): ScheduleEntity

--- a/data/src/main/java/com/wap/data/local/ScheduleLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/wap/data/local/ScheduleLocalDataSourceImpl.kt
@@ -9,11 +9,15 @@ import com.wap.domain.entity.Schedule
 import com.wap.domain.entity.WeekType
 import com.wap.domain.datasource.ScheduleDataSource
 import java.time.LocalDateTime
+import java.time.LocalTime
 import javax.inject.Inject
 
+@RequiresApi(Build.VERSION_CODES.O)
 class ScheduleLocalDataSourceImpl @Inject constructor(
     private val scheduleDao: ScheduleDao
 ) : ScheduleDataSource {
+
+    private fun LocalDateTime.startDateMax() = LocalDateTime.of(this.toLocalDate(), LocalTime.MAX)
 
     override fun getSchedule(scheduleId: Long): Schedule {
         TODO()
@@ -25,7 +29,8 @@ class ScheduleLocalDataSourceImpl @Inject constructor(
     } ?: emptyList()
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun findSchedulesByStartTime(startTime: LocalDateTime) = scheduleDao.findSchedulesByStartDate(startTime)?.map { scheduleEntity ->
+    override fun findSchedulesByStartTime(startTime: LocalDateTime)
+    = scheduleDao.findSchedulesByStartDate(startDateMin = startTime, startDateMax = startTime.startDateMax())?.map { scheduleEntity ->
         scheduleEntity.toSchedule()
     } ?: emptyList()
 

--- a/data/src/main/java/com/wap/data/repository/ScheduleRepository.kt
+++ b/data/src/main/java/com/wap/data/repository/ScheduleRepository.kt
@@ -55,9 +55,7 @@ class ScheduleRepository @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    override fun findSchedulesByStartTime(startTime: LocalDateTime): List<Schedule> {
-        TODO("Not yet implemented")
-    }
+    override fun findSchedulesByStartTime(startTime: LocalDateTime): List<Schedule> = scheduleDataSource.findSchedulesByStartTime(startTime)
 
     override fun createSchedule(schedule: Schedule) {
         scheduleDataSource.createSchedule(schedule)


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #106

## Changes
[`ScheduleDao - findSchedulesByStartDate`]
- `startDateMin`(0 : 0 : 0), `startDateMax`(23 : 59 : 59)를 받는다
- `startTime`이 둘 사이에 있으면 `Min`,`Max`사이에 있으면 반환한다.

---

[`ScheduleLocalDataSourceImpl`]
- `startTime`을 받는다. (`startTime`은 `CalendarDay`를 `toLocalDateTime` 했기 때문에 기본이 `Min`값이다.)
- `startTime`에 `LocalTime.Max`를 해서 `startDateMax`값을 넣어준다.

---

[`ScheduleViewModel - fetchSchedules`]
- `FakeFactory`에서 생성하던 일정을 `Database`에서 가져오는 것으로 변경했다.

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
<!-- 비고
- 트러블슈팅 공유, 고민 등을 서술
-->