### PR TITLE
일정 추가/수정 화면 뒤로가기

### DIFF
--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/AddEditScheduleActivity.kt
@@ -58,7 +58,8 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
             binding.composeScheduleTopAppbar.setContent {
                 AddEditScheduleTopAppBar(
                     deleteButtonState = scheduleViewModel.addEditDeleteButtonState,
-                    onClickDeleteButton = { scheduleViewModel.deleteCheckedSchedules() }
+                    onClickDeleteButton = { scheduleViewModel.deleteCheckedSchedules() },
+                    onClickBackArrow = { finish() }
                 )
             }
         }
@@ -118,7 +119,10 @@ class AddEditScheduleActivity : BaseActivity<ActivityScheduleBinding>(R.layout.a
 
     private fun setSaveButton() {
         binding.composeScheduleSaveButton.setContent {
-            SaveButton { scheduleViewModel.saveButtonEvent() }
+            SaveButton {
+                scheduleViewModel.saveButtonEvent()
+                finish()
+            }
         }
     }
 

--- a/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/AddEditScheduleTopAppBar.kt
+++ b/app/src/main/java/com/wap/storemanagement/ui/schedule/composeview/AddEditScheduleTopAppBar.kt
@@ -17,7 +17,8 @@ import com.wap.storemanagement.ui.schedule.DeleteButtonState
 @Composable
 fun AddEditScheduleTopAppBar(
     deleteButtonState: DeleteButtonState,
-    onClickDeleteButton: () -> Unit
+    onClickDeleteButton: () -> Unit,
+    onClickBackArrow: () -> Unit
 ) {
     val backgroundColor = colorResource(id = R.color.schedule_top_appbar_background)
 
@@ -25,7 +26,7 @@ fun AddEditScheduleTopAppBar(
         title = { Text(text = stringResource(R.string.schedule_top_appbar_title)) },
         backgroundColor = backgroundColor,
         navigationIcon = {
-            IconButton(onClick = { }) {
+            IconButton(onClick = { onClickBackArrow() }) {
                 Icon(Icons.Default.ArrowBackIos, "ArrowBack")
             }
         },
@@ -63,6 +64,7 @@ private fun DeleteButton(
 fun PreviewAddScheduleTopAppBar() {
     AddEditScheduleTopAppBar(
         deleteButtonState = DeleteButtonState.ON,
-        onClickDeleteButton = {}
+        onClickDeleteButton = {},
+        onClickBackArrow = {}
     )
 }


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
- Resolve: #104 

## Changes
- 상단바 뒤로가기 버튼 : 저장 X, `HomeFragment`로 이동
- 저장 버튼 : 저장 O, `HomeFragment`로 이동

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->

## etc
[ 문제 ]
- 뒤로갔을 때 변경된 일정이 화면에 바로 적용되지 않았습니다.
- 날짜를 다시 선택해야 변경된 일정을 확인 할 수 있습니다.

[ 고민 ]
- `DB`에서 초기 값을 가져오는 `currenDateSchedules` `Flow<>`과
- `memory` 상에서만 이용되는 `memoryCurrentDateSchedules` `liveData`로 나누려 했으나
- 지금 있는 `_currenDateSchedules`를 너무 여러곳에서 `set`하고 있어서 생각보다 변경할 사항이 많았습니다.
- 나중에 한번 대공사를 해야할 것 같습니다 ㅠ..
- `Flow`로 변경하면 #108 도 해결하기 편할 것 같습니다